### PR TITLE
Thunn/add convert for frequency to midi

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install pytest
+          pip install soundfile pytest
       - name: Run core tests
         run: |
           python -m pytest --ignore test/test_convert.py

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.10"]
 
     steps:
       - uses: actions/checkout@v4
@@ -15,11 +15,17 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - name: Install base dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-      - name: Run tests
-        run: |
           pip install pytest
+      - name: Run core tests
+        run: |
+          python -m pytest --ignore test/test_convert.py
+      - name: Install additional test dependencies
+        run: |
+          pip install -e '.[test]'
+      - name: Run all tests
+        run: |
           python -m pytest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install base dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,9 +19,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-      - name: Display Python version
-        run: |
-          python -c "import sys; print(sys.version)"
       - name: Run tests
         run: |
           pip install pytest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,28 @@
+name: run
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Display Python version
+        run: |
+          python -c "import sys; print(sys.version)"
+      - name: Run tests
+        run: |
+          pip install pytest
+          python -m pytest

--- a/penn/convert.py
+++ b/penn/convert.py
@@ -45,6 +45,21 @@ def frequency_to_samples(frequency, sample_rate=penn.SAMPLE_RATE):
     """Convert frequency in Hz to number of samples per period"""
     return sample_rate / frequency
 
+def frequency_to_midi(frequency):
+    """
+    Convert frequency to MIDI note number(s)
+    Based on librosa.hz_to_midi(frequencies) implementation
+    https://librosa.org/doc/main/_modules/librosa/core/convert.html#hz_to_midi
+    """
+    return 12 * (torch.log2(frequency) - torch.log2(torch.tensor(440.0))) + 69
+
+def midi_to_frequency(midi):
+    """
+    Convert MIDI note number to frequency
+    Based on librosa.midi_to_hz(notes) implementation
+    https://librosa.org/doc/main/_modules/librosa/core/convert.html#midi_to_hz
+    """
+    return 440.0 * (2.0 ** ((midi - 69.0) / 12.0))
 
 ###############################################################################
 # Time conversions

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ setup(
             'pyworld',     # 0.3.2
             'scipy',       # 1.9.3
             'torchcrepe'   # 0.0.17
+        ],
+        'test': [
+            'librosa',     # 0.9.1
         ]
     },
     install_requires=[

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -1,0 +1,32 @@
+import penn
+
+import librosa
+import torch
+
+
+###############################################################################
+# Test convert.py
+###############################################################################
+
+
+def test_convert_frequency_to_midi(audio):
+    """Test that conversion from Hz to MIDI matches librosa implementation"""
+
+    sample_data = torch.tensor([110.0, 220.0, 440.0, 500.0, 880.0])
+
+    penn_midi = penn.convert.frequency_to_midi(sample_data)
+
+    librosa_midi = librosa.hz_to_midi(sample_data.numpy())
+
+    assert torch.allclose(penn_midi, torch.tensor(librosa_midi))
+
+def test_convert_midi_to_frequency(audio):
+    """Test that conversion from MIDI to Hz matches librosa implementation"""
+
+    sample_data = torch.tensor([45.0, 57.0, 69.0, 71.2131, 81.0])   
+
+    penn_frequency = penn.convert.midi_to_frequency(sample_data)
+
+    librosa_frequency = librosa.midi_to_hz(sample_data.numpy())
+
+    assert torch.allclose(penn_frequency, torch.tensor(librosa_frequency))

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -12,7 +12,7 @@ import torch
 def test_convert_frequency_to_midi(audio):
     """Test that conversion from Hz to MIDI matches librosa implementation"""
 
-    sample_data = torch.tensor([110.0, 220.0, 440.0, 500.0, 880.0])
+    sample_data = torch.tensor([110.0, 220.0, 440.0, 500.0, 880.0], dtype=torch.float32)
 
     penn_midi = penn.convert.frequency_to_midi(sample_data)
 
@@ -23,7 +23,7 @@ def test_convert_frequency_to_midi(audio):
 def test_convert_midi_to_frequency(audio):
     """Test that conversion from MIDI to Hz matches librosa implementation"""
 
-    sample_data = torch.tensor([45.0, 57.0, 69.0, 71.2131, 81.0])   
+    sample_data = torch.tensor([45.0, 57.0, 69.0, 71.2131, 81.0], dtype=torch.float32)   
 
     penn_frequency = penn.convert.midi_to_frequency(sample_data)
 

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -9,24 +9,24 @@ import torch
 ###############################################################################
 
 
-def test_convert_frequency_to_midi(audio):
+def test_convert_frequency_to_midi():
     """Test that conversion from Hz to MIDI matches librosa implementation"""
 
-    sample_data = torch.tensor([110.0, 220.0, 440.0, 500.0, 880.0], dtype=torch.float32)
+    sample_data = torch.tensor([110.0, 220.0, 440.0, 500.0, 880.0])
 
     penn_midi = penn.convert.frequency_to_midi(sample_data)
 
     librosa_midi = librosa.hz_to_midi(sample_data.numpy())
 
-    assert torch.allclose(penn_midi, torch.tensor(librosa_midi))
+    assert torch.allclose(penn_midi, torch.tensor(librosa_midi, dtype=torch.float32))
 
-def test_convert_midi_to_frequency(audio):
+def test_convert_midi_to_frequency():
     """Test that conversion from MIDI to Hz matches librosa implementation"""
 
-    sample_data = torch.tensor([45.0, 57.0, 69.0, 71.2131, 81.0], dtype=torch.float32)   
+    sample_data = torch.tensor([45.0, 57.0, 69.0, 71.2131, 81.0])   
 
     penn_frequency = penn.convert.midi_to_frequency(sample_data)
 
     librosa_frequency = librosa.midi_to_hz(sample_data.numpy())
 
-    assert torch.allclose(penn_frequency, torch.tensor(librosa_frequency))
+    assert torch.allclose(penn_frequency, torch.tensor(librosa_frequency, dtype=torch.float32))


### PR DESCRIPTION
Added convert functions (https://github.com/interactiveaudiolab/penn/issues/13):
    - frequency_to_midi(frequency) -> midi notes
    - midi_to_frequency(midi) -> frequency

Implemented in torch based on librosa numpy implementations.

Added tests to confirm outputs match librosa.

Added github workflows to run pytest. (these could optionally be removed form the pr)

